### PR TITLE
Added RenameParamToMatchTypeRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "autoload": {
         "psr-4": {
+            "Architector\\Set\\ValueObject\\": "packages/Set/ValueObject/",
             "SprykerSdk\\": "src/SprykerSdk/"
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=7.4",
         "ext-dom": "*",
         "ext-simplexml": "*",
-        "rector/rector": "^0.11.42"
+        "rector/rector": "^0.11.42 || ^0.12.0"
     },
     "require-dev": {
         "codeception/codeception": "^4.1.0",

--- a/docs/rules_overview.md
+++ b/docs/rules_overview.md
@@ -1,4 +1,4 @@
-# 10 Rules Overview
+# 11 Rules Overview
 
 ## PresentationToControllerConfigRector
 
@@ -156,6 +156,54 @@ Removes the initial comment in tester classes.
 -    /**
 -     * Define custom actions here
 -     */
+ }
+```
+
+<br>
+
+## RenameParamToMatchTypeRector
+
+Rename param to match ClassType
+
+- class: [`SprykerSdk\Architector\Rename\RenameParamToMatchTypeRector`](../src/SprykerSdk/Architector/Rename/RenameParamToMatchTypeRector.php)
+
+```diff
+ class SomeClass
+ {
+-    public function run(FooBarTransfer $fooBar)
++    public function run(FooBarTransfer $fooBarTransfer)
+     {
+-        $foo = $fooBar;
++        $foo = $fooBarTransfer;
+     }
+ }
+```
+
+<br>
+
+```diff
+ class SomeClass
+ {
+-    public function run(SpyFooBar $fooBar)
++    public function run(SpyFooBar $fooBarEntity)
+     {
+-        $foo = $fooBar;
++        $foo = $fooBarEntity;
+     }
+ }
+```
+
+<br>
+
+```diff
+ class SomeClass
+ {
+-    public function run(SpyFooBarQuery $fooBar)
++    public function run(SpyFooBarQuery $fooBarQuery)
+     {
+-        $foo = $fooBar;
++        $foo = $fooBarQuery;
+     }
  }
 ```
 

--- a/packages/Set/ValueObject/ArchitectorSetList.php
+++ b/packages/Set/ValueObject/ArchitectorSetList.php
@@ -1,0 +1,30 @@
+<?php
+
+declare (strict_types=1);
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Architector\Set\ValueObject;
+
+use Rector\Set\Contract\SetListInterface;
+
+final class ArchitectorSetList implements SetListInterface
+{
+    /**
+     * @var string
+     */
+    public const CODECEPTION = __DIR__ . '/../../../sets/Codeception/presentation-to-controller-test.php';
+
+    /**
+     * @var string
+     */
+    public const RENAME = __DIR__ . '/../../../sets/Rename/rename-param-to-match-type.php';
+
+    /**
+     * @var string
+     */
+    public const TRIGGER_ERROR = __DIR__ . '/../../../sets/Rfc/TriggerError/config.php';
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,2 @@
+parameters:
+	checkMissingIterableValueType: false

--- a/sets/Rename/rename-param-to-match-type.php
+++ b/sets/Rename/rename-param-to-match-type.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright © 2021-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+declare(strict_types = 1);
+
+use SprykerSdk\Architector\Rename\RenameParamToMatchTypeRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (
+    ContainerConfigurator $containerConfigurator
+): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(RenameParamToMatchTypeRector::class);
+};

--- a/src/SprykerSdk/Architector/Codeception/PresentationToControllerConfig/PresentationToControllerConfigFileProcessor.php
+++ b/src/SprykerSdk/Architector/Codeception/PresentationToControllerConfig/PresentationToControllerConfigFileProcessor.php
@@ -8,6 +8,8 @@
 namespace SprykerSdk\Architector\Codeception\PresentationToControllerConfig;
 
 use Rector\Core\Contract\Processor\FileProcessorInterface;
+use Rector\Core\ValueObject\Application\File;
+use Rector\Core\ValueObject\Configuration;
 
 final class PresentationToControllerConfigFileProcessor implements FileProcessorInterface
 {
@@ -30,7 +32,7 @@ final class PresentationToControllerConfigFileProcessor implements FileProcessor
      *
      * @return bool
      */
-    public function supports($file, $configuration): bool
+    public function supports(File $file, Configuration $configuration): bool
     {
         $smartFileInfo = $file->getSmartFileInfo();
 
@@ -41,14 +43,16 @@ final class PresentationToControllerConfigFileProcessor implements FileProcessor
      * @param \Rector\Core\ValueObject\Application\File $file
      * @param \Rector\Core\ValueObject\Configuration $configuration
      *
-     * @return void
+     * @return array
      */
-    public function process($file, $configuration): void
+    public function process(File $file, Configuration $configuration): array
     {
         foreach ($this->rectors as $rector) {
             $changeFileContent = $rector->transform($file->getFileContent());
             $file->changeFileContent($changeFileContent);
         }
+
+        return [];
     }
 
     /**

--- a/src/SprykerSdk/Architector/Codeception/PresentationToControllerConfig/PresentationToControllerConfigFileProcessor.php
+++ b/src/SprykerSdk/Architector/Codeception/PresentationToControllerConfig/PresentationToControllerConfigFileProcessor.php
@@ -12,12 +12,12 @@ use Rector\Core\Contract\Processor\FileProcessorInterface;
 final class PresentationToControllerConfigFileProcessor implements FileProcessorInterface
 {
     /**
-     * @var array<PresentationToControllerConfigRectorInterface>
+     * @var array<\SprykerSdk\Architector\Codeception\PresentationToControllerConfig\PresentationToControllerConfigRectorInterface>
      */
     private $rectors;
 
     /**
-     * @param array<PresentationToControllerConfigRectorInterface> $rectors
+     * @param array<\SprykerSdk\Architector\Codeception\PresentationToControllerConfig\PresentationToControllerConfigRectorInterface> $rectors
      */
     public function __construct(array $rectors)
     {

--- a/src/SprykerSdk/Architector/Codeception/PresentationToControllerConfig/PresentationToControllerConfigRector.php
+++ b/src/SprykerSdk/Architector/Codeception/PresentationToControllerConfig/PresentationToControllerConfigRector.php
@@ -83,7 +83,7 @@ class PresentationToControllerConfigRector implements PresentationToControllerCo
 
         $ymlAsArray['suites']['Controller']['modules']['enabled'] = $filteredEnabledModules;
 
-        return Yaml::dump($ymlAsArray);
+        return Yaml::dump($ymlAsArray, 50);
     }
 
     /**

--- a/src/SprykerSdk/Architector/Codeception/PresentationToControllerConfig/PresentationToControllerConfigRector.php
+++ b/src/SprykerSdk/Architector/Codeception/PresentationToControllerConfig/PresentationToControllerConfigRector.php
@@ -14,7 +14,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 class PresentationToControllerConfigRector implements PresentationToControllerConfigRectorInterface
 {
     /**
-     * @var string[]
+     * @var array<string>
      */
     private $modulesToAdd = [
         '\SprykerTest\Shared\Testify\Helper\Environment',
@@ -23,7 +23,7 @@ class PresentationToControllerConfigRector implements PresentationToControllerCo
     ];
 
     /**
-     * @var string[]
+     * @var array<string>
      */
     private $modulesToRemove = [
         'Asserts',
@@ -91,17 +91,24 @@ class PresentationToControllerConfigRector implements PresentationToControllerCo
      */
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Moves configuration from Presentation to Communication tests.', [new CodeSample(<<<'CODE_SAMPLE'
-suites:
-    Presentation:
-        path: Presentation
-        class_name: XyPresentationTester
-CODE_SAMPLE, <<<'CODE_SAMPLE'
-suites:
-    Communication:
-        path: Communication
-        class_name: XyCommunicationTester
-CODE_SAMPLE
-        )]);
+        return new RuleDefinition(
+            'Moves configuration from Presentation to Communication tests.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    suites:
+                        Presentation:
+                            path: Presentation
+                            class_name: XyPresentationTester
+                    CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                    suites:
+                        Communication:
+                            path: Communication
+                            class_name: XyCommunicationTester
+                    CODE_SAMPLE,
+                ),
+            ],
+        );
     }
 }

--- a/src/SprykerSdk/Architector/Codeception/PresentationToControllerTest/PresentationToControllerTestClassContFetchRector.php
+++ b/src/SprykerSdk/Architector/Codeception/PresentationToControllerTest/PresentationToControllerTestClassContFetchRector.php
@@ -17,7 +17,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 class PresentationToControllerTestClassContFetchRector extends AbstractRector
 {
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -47,11 +47,18 @@ class PresentationToControllerTestClassContFetchRector extends AbstractRector
      */
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Replace usages of XPresentationTester::const with XControllerTester::const', [new CodeSample(<<<'CODE_SAMPLE'
+        return new RuleDefinition(
+            'Replace usages of XPresentationTester::const with XControllerTester::const',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 $foo = XPresentationTester::const;
-CODE_SAMPLE, <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 $foo = XControllerTester::const;
-CODE_SAMPLE
-        )]);
+CODE_SAMPLE,
+                ),
+            ],
+        );
     }
 }

--- a/src/SprykerSdk/Architector/Codeception/PresentationToControllerTest/PresentationToControllerTestFileMoveRector.php
+++ b/src/SprykerSdk/Architector/Codeception/PresentationToControllerTest/PresentationToControllerTestFileMoveRector.php
@@ -31,7 +31,7 @@ class PresentationToControllerTestFileMoveRector extends AbstractRector
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -65,19 +65,26 @@ class PresentationToControllerTestFileMoveRector extends AbstractRector
      */
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Moves Presentation test files to Controller directory', [new CodeSample(<<<'CODE_SAMPLE'
+        return new RuleDefinition(
+            'Moves Presentation test files to Controller directory',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 // file: tests/Presentation/SomeTest.php
 namespace Foo\Presentation;
 class SomeTest
 {
 }
-CODE_SAMPLE, <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 // file: tests/Controller/SomeTest.php
 namespace Foo\Controller;
 class SomeTest
 {
 }
-CODE_SAMPLE
-        )]);
+CODE_SAMPLE,
+                ),
+            ],
+        );
     }
 }

--- a/src/SprykerSdk/Architector/Codeception/PresentationToControllerTest/PresentationToControllerTestMethodParamRector.php
+++ b/src/SprykerSdk/Architector/Codeception/PresentationToControllerTest/PresentationToControllerTestMethodParamRector.php
@@ -43,7 +43,7 @@ class PresentationToControllerTestMethodParamRector extends AbstractRector
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -68,7 +68,7 @@ class PresentationToControllerTestMethodParamRector extends AbstractRector
                 continue;
             }
 
-            /** @var Node\Name $name */
+            /** @var \PhpParser\Node\Name $name */
             $name = $param->type;
             $parts = $name->parts;
             $className = (string)array_pop($parts);
@@ -82,7 +82,7 @@ class PresentationToControllerTestMethodParamRector extends AbstractRector
             $className = str_replace(
                 'PresentationTester',
                 'ControllerTester',
-                $className
+                $className,
             );
 
             array_push($parts, $className);
@@ -102,7 +102,7 @@ class PresentationToControllerTestMethodParamRector extends AbstractRector
     }
 
     /**
-     * @param Node\Param $param
+     * @param \PhpParser\Node\Param $param
      * @param string $className
      *
      * @return void
@@ -120,7 +120,7 @@ class PresentationToControllerTestMethodParamRector extends AbstractRector
     }
 
     /**
-     * @param Node\Param $param
+     * @param \PhpParser\Node\Param $param
      * @param \PhpParser\Node\Stmt\ClassMethod $classMethod
      * @param string $className
      *
@@ -148,7 +148,11 @@ class PresentationToControllerTestMethodParamRector extends AbstractRector
      */
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Refactors method arguments and doc blocks from using XPresentationTester to XControllerTester', [new CodeSample(<<<'CODE_SAMPLE'
+        return new RuleDefinition(
+            'Refactors method arguments and doc blocks from using XPresentationTester to XControllerTester',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 namespace Foo\Presentation;
 class SomeTest
 {
@@ -159,7 +163,8 @@ class SomeTest
      */
     public function test(XPresentationTester $i) {}
 }
-CODE_SAMPLE, <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 namespace Foo\Presentation;
 class SomeTest
 {
@@ -170,7 +175,9 @@ class SomeTest
      */
     public function test(XControllerTester $i) {}
 }
-CODE_SAMPLE
-        )]);
+CODE_SAMPLE,
+                ),
+            ],
+        );
     }
 }

--- a/src/SprykerSdk/Architector/Codeception/PresentationToControllerTest/PresentationToControllerTestNamespaceRector.php
+++ b/src/SprykerSdk/Architector/Codeception/PresentationToControllerTest/PresentationToControllerTestNamespaceRector.php
@@ -30,7 +30,7 @@ class PresentationToControllerTestNamespaceRector extends AbstractRector
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -62,19 +62,26 @@ class PresentationToControllerTestNamespaceRector extends AbstractRector
      */
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Refactors namespace from Presentation to Controller', [new CodeSample(<<<'CODE_SAMPLE'
+        return new RuleDefinition(
+            'Refactors namespace from Presentation to Controller',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 namespace Foo\Presentation;
 
 class SomeTest
 {
 }
-CODE_SAMPLE, <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 namespace Foo\Controller;
 
 class SomeTest
 {
 }
-CODE_SAMPLE
-        )]);
+CODE_SAMPLE,
+                ),
+            ],
+        );
     }
 }

--- a/src/SprykerSdk/Architector/Codeception/PresentationToControllerTester/PresentationToControllerTesterClassNameRector.php
+++ b/src/SprykerSdk/Architector/Codeception/PresentationToControllerTester/PresentationToControllerTesterClassNameRector.php
@@ -30,7 +30,7 @@ class PresentationToControllerTesterClassNameRector extends AbstractRector
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -60,17 +60,24 @@ class PresentationToControllerTesterClassNameRector extends AbstractRector
      */
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Renames PresentationTester to ControllerTester', [new CodeSample(<<<'CODE_SAMPLE'
+        return new RuleDefinition(
+            'Renames PresentationTester to ControllerTester',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 namespace Foo\Presentation;
 class SomePresentationTester
 {
 }
-CODE_SAMPLE, <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 namespace Foo\Controller;
 class SomeControllerTester
 {
 }
-CODE_SAMPLE
-        )]);
+CODE_SAMPLE,
+                ),
+            ],
+        );
     }
 }

--- a/src/SprykerSdk/Architector/Codeception/PresentationToControllerTester/PresentationToControllerTesterFileMoveRector.php
+++ b/src/SprykerSdk/Architector/Codeception/PresentationToControllerTester/PresentationToControllerTesterFileMoveRector.php
@@ -11,25 +11,11 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use Rector\Core\Rector\AbstractRector;
 use Rector\FileSystemRector\ValueObject\AddedFileWithNodes;
-use SprykerSdk\Architector\Codeception\RectorHelper\TestSuiteHelper;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 class PresentationToControllerTesterFileMoveRector extends AbstractRector
 {
-    /**
-     * @var \SprykerSdk\Architector\Codeception\RectorHelper\TestSuiteHelper
-     */
-    private $testSuiteHelper;
-
-    /**
-     * @param \SprykerSdk\Architector\Codeception\RectorHelper\TestSuiteHelper $testSuiteHelper
-     */
-    public function __construct(TestSuiteHelper $testSuiteHelper)
-    {
-        $this->testSuiteHelper = $testSuiteHelper;
-    }
-
     /**
      * @return array<class-string<\PhpParser\Node>>
      */

--- a/src/SprykerSdk/Architector/Codeception/PresentationToControllerTester/PresentationToControllerTesterFileMoveRector.php
+++ b/src/SprykerSdk/Architector/Codeception/PresentationToControllerTester/PresentationToControllerTesterFileMoveRector.php
@@ -31,7 +31,7 @@ class PresentationToControllerTesterFileMoveRector extends AbstractRector
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -66,19 +66,26 @@ class PresentationToControllerTesterFileMoveRector extends AbstractRector
      */
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Moves Presentation test to Controller test suite namespace', [new CodeSample(<<<'CODE_SAMPLE'
+        return new RuleDefinition(
+            'Moves Presentation test to Controller test suite namespace',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 // file: tests/Presentation/SomeTest.php
 namespace Foo\Presentation;
 class SomePresentationTest
 {
 }
-CODE_SAMPLE, <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 // file: tests/Controller/SomeTest.php
 namespace Foo\Controller;
 class SomeTest
 {
 }
-CODE_SAMPLE
-        )]);
+CODE_SAMPLE,
+                ),
+            ],
+        );
     }
 }

--- a/src/SprykerSdk/Architector/Codeception/PresentationToControllerTester/PresentationToControllerTesterTraitUseRector.php
+++ b/src/SprykerSdk/Architector/Codeception/PresentationToControllerTester/PresentationToControllerTesterTraitUseRector.php
@@ -30,7 +30,7 @@ class PresentationToControllerTesterTraitUseRector extends AbstractRector
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -50,7 +50,7 @@ class PresentationToControllerTesterTraitUseRector extends AbstractRector
 
         $isModified = false;
 
-        /** @var Node\Name\FullyQualified $trait */
+        /** @var \PhpParser\Node\Name\FullyQualified $trait */
         foreach ($node->traits as $trait) {
             $traitNameParts = $trait->parts;
             $lastElement = (string)end($traitNameParts);
@@ -75,19 +75,26 @@ class PresentationToControllerTesterTraitUseRector extends AbstractRector
      */
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Renames trait use from Presentation to Controller namespace', [new CodeSample(<<<'CODE_SAMPLE'
+        return new RuleDefinition(
+            'Renames trait use from Presentation to Controller namespace',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 namespace Foo\Presentation;
 class SomeTest
 {
     use _generated\XPresentationTesterActions;
 }
-CODE_SAMPLE, <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 namespace Foo\Presentation;
 class SomeTest
 {
     use _generated\XControllerTesterActions;
 }
-CODE_SAMPLE
-        )]);
+CODE_SAMPLE,
+                ),
+            ],
+        );
     }
 }

--- a/src/SprykerSdk/Architector/Codeception/RectorHelper/TestSuiteHelper.php
+++ b/src/SprykerSdk/Architector/Codeception/RectorHelper/TestSuiteHelper.php
@@ -62,7 +62,7 @@ class TestSuiteHelper
     public function isSuite(string $expectedSuiteName, Node $node): bool
     {
         if ($node instanceof Class_) {
-            $namespacedNameParts = $node->namespacedName->parts ?? [];
+            $namespacedNameParts = $node->namespacedName->parts;
 
             if ((isset($namespacedNameParts[3]) && $namespacedNameParts[3] === $expectedSuiteName)) {
                 return true;
@@ -75,7 +75,7 @@ class TestSuiteHelper
             /** @var \PhpParser\Node\Stmt\Class_ $parentNode */
             $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 
-            $namespacedNameParts = $parentNode->namespacedName->parts ?? [];
+            $namespacedNameParts = $parentNode->namespacedName->parts;
 
             if ($parentNode instanceof Class_ && (isset($namespacedNameParts[3]) && $namespacedNameParts[3] === $expectedSuiteName)) {
                 return true;

--- a/src/SprykerSdk/Architector/Codeception/RectorHelper/TestSuiteHelper.php
+++ b/src/SprykerSdk/Architector/Codeception/RectorHelper/TestSuiteHelper.php
@@ -38,7 +38,7 @@ class TestSuiteHelper
     public function isPresentationTesterActions(Node $node): bool
     {
         if ($node instanceof TraitUse) {
-            /** @var Node\Name\FullyQualified $trait */
+            /** @var \PhpParser\Node\Name\FullyQualified $trait */
             foreach ($node->traits as $trait) {
                 $traitNameParts = $trait->parts;
                 $lastElement = (string)end($traitNameParts);

--- a/src/SprykerSdk/Architector/Codeception/RemoveInitialTesterComment/RemoveInitialTesterCommentRector.php
+++ b/src/SprykerSdk/Architector/Codeception/RemoveInitialTesterComment/RemoveInitialTesterCommentRector.php
@@ -16,7 +16,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 class RemoveInitialTesterCommentRector extends AbstractRector
 {
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -47,7 +47,11 @@ class RemoveInitialTesterCommentRector extends AbstractRector
      */
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Removes the initial comment in tester classes.', [new CodeSample(<<<'CODE_SAMPLE'
+        return new RuleDefinition(
+            'Removes the initial comment in tester classes.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 class SomeTest
 {
     use _generated\XPresentationTesterActions;
@@ -56,12 +60,15 @@ class SomeTest
      * Define custom actions here
      */
 }
-CODE_SAMPLE, <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 class SomeTest
 {
     use _generated\XPresentationTesterActions;
 }
-CODE_SAMPLE
-        )]);
+CODE_SAMPLE,
+                ),
+            ],
+        );
     }
 }

--- a/src/SprykerSdk/Architector/Rename/RenameParamToMatchTypeRector.php
+++ b/src/SprykerSdk/Architector/Rename/RenameParamToMatchTypeRector.php
@@ -1,0 +1,232 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdk\Architector\Rename;
+
+use PhpParser\Node;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\MethodName;
+use Rector\Naming\ExpectedNameResolver\MatchParamTypeExpectedNameResolver;
+use Rector\Naming\Guard\BreakingVariableRenameGuard;
+use Rector\Naming\Naming\ExpectedNameResolver;
+use Rector\Naming\ParamRenamer\ParamRenamer;
+use Rector\Naming\ValueObject\ParamRename;
+use Rector\Naming\ValueObjectFactory\ParamRenameFactory;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class RenameParamToMatchTypeRector extends AbstractRector
+{
+    /**
+     * @var bool
+     */
+    private $hasChanged = false;
+
+    /**
+     * @var \Rector\Naming\Guard\BreakingVariableRenameGuard
+     */
+    private $breakingVariableRenameGuard;
+
+    /**
+     * @var \Rector\Naming\Naming\ExpectedNameResolver
+     */
+    private $expectedNameResolver;
+
+    /**
+     * @var \Rector\Naming\ExpectedNameResolver\MatchParamTypeExpectedNameResolver
+     */
+    private $matchParamTypeExpectedNameResolver;
+
+    /**
+     * @var \Rector\Naming\ValueObjectFactory\ParamRenameFactory
+     */
+    private $paramRenameFactory;
+
+    /**
+     * @var \Rector\Naming\ParamRenamer\ParamRenamer
+     */
+    private $paramRenamer;
+
+    public function __construct(
+        BreakingVariableRenameGuard $breakingVariableRenameGuard,
+        ExpectedNameResolver $expectedNameResolver,
+        MatchParamTypeExpectedNameResolver $matchParamTypeExpectedNameResolver,
+        ParamRenameFactory $paramRenameFactory,
+        ParamRenamer $paramRenamer
+    ) {
+        $this->breakingVariableRenameGuard = $breakingVariableRenameGuard;
+        $this->expectedNameResolver = $expectedNameResolver;
+        $this->matchParamTypeExpectedNameResolver = $matchParamTypeExpectedNameResolver;
+        $this->paramRenameFactory = $paramRenameFactory;
+        $this->paramRenamer = $paramRenamer;
+    }
+
+    /**
+     * @return RuleDefinition
+     * @throws \Symplify\RuleDocGenerator\Exception\PoorDocumentationException
+     */
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Rename param to match ClassType',
+            [
+                new CodeSample(<<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run(FooBarTransfer $fooBar)
+    {
+        $foo = $fooBar;
+    }
+}
+CODE_SAMPLE
+                    , <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run(FooBarTransfer $fooBarTransfer)
+    {
+        $foo = $fooBarTransfer;
+    }
+}
+CODE_SAMPLE
+                ),
+                new CodeSample(<<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run(SpyFooBar $fooBar)
+    {
+        $foo = $fooBar;
+    }
+}
+CODE_SAMPLE
+                    , <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run(SpyFooBar $fooBarEntity)
+    {
+        $foo = $fooBarEntity;
+    }
+}
+CODE_SAMPLE
+                ),
+                new CodeSample(<<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run(SpyFooBarQuery $fooBar)
+    {
+        $foo = $fooBar;
+    }
+}
+CODE_SAMPLE
+                    , <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run(SpyFooBarQuery $fooBarQuery)
+    {
+        $foo = $fooBarQuery;
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $this->hasChanged = \false;
+
+        foreach ($node->params as $param) {
+            $expectedName = $this->expectedNameResolver->resolveForParamIfNotYet($param);
+            $expectedName = $this->getExpectedName($expectedName);
+
+            if ($expectedName === null) {
+                continue;
+            }
+
+            if ($this->shouldSkipParam($param, $expectedName, $node)) {
+                continue;
+            }
+
+            $expectedName = $this->matchParamTypeExpectedNameResolver->resolve($param);
+            $expectedName = $this->getExpectedName($expectedName);
+
+            if ($expectedName === null) {
+                continue;
+            }
+
+            $paramRename = $this->paramRenameFactory->createFromResolvedExpectedName($param, $expectedName);
+
+            if (!$paramRename instanceof ParamRename) {
+                continue;
+            }
+
+            $this->paramRenamer->rename($paramRename);
+            $this->hasChanged = \true;
+        }
+        if (!$this->hasChanged) {
+            return null;
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param string $expectedName
+     *
+     * @return string
+     */
+    protected function getExpectedName(string $expectedName): string
+    {
+        // Propel Query
+        if (preg_match('/^spy[a-zA-Z]+Query/', $expectedName)) {
+            return lcfirst(ltrim($expectedName, 'spy'));
+        }
+
+        // Propel Entity
+        if (preg_match('/^spy[a-zA-Z]+/', $expectedName)) {
+            return lcfirst(ltrim($expectedName, 'spy')) . 'Entity';
+        }
+
+        return $expectedName;
+    }
+
+    /**
+     * @param \PhpParser\Node\Param $param
+     * @param string $expectedName
+     * @param \PhpParser\Node\Stmt\ClassMethod $classMethod
+     *
+     * @return bool
+     */
+    protected function shouldSkipParam(Param $param, string $expectedName, ClassMethod $classMethod): bool
+    {
+        /** @var string $paramName */
+        $paramName = $this->getName($param);
+
+        if ($this->breakingVariableRenameGuard->shouldSkipParam($paramName, $expectedName, $classMethod, $param)) {
+            return \true;
+        }
+
+        // promoted property
+        if (!$this->isName($classMethod, MethodName::CONSTRUCT)) {
+            return \false;
+        }
+
+        return $param->flags !== 0;
+    }
+}

--- a/src/SprykerSdk/Architector/Rename/RenameParamToMatchTypeRector.php
+++ b/src/SprykerSdk/Architector/Rename/RenameParamToMatchTypeRector.php
@@ -153,22 +153,24 @@ CODE_SAMPLE
 
         foreach ($node->params as $param) {
             $expectedName = $this->expectedNameResolver->resolveForParamIfNotYet($param);
-            $expectedName = $this->getExpectedName($expectedName);
 
             if ($expectedName === null) {
                 continue;
             }
+
+            $expectedName = $this->getExpectedName($expectedName);
 
             if ($this->shouldSkipParam($param, $expectedName, $node)) {
                 continue;
             }
 
             $expectedName = $this->matchParamTypeExpectedNameResolver->resolve($param);
-            $expectedName = $this->getExpectedName($expectedName);
 
             if ($expectedName === null) {
                 continue;
             }
+            
+            $expectedName = $this->getExpectedName($expectedName);
 
             $paramRename = $this->paramRenameFactory->createFromResolvedExpectedName($param, $expectedName);
 

--- a/src/SprykerSdk/Architector/Rename/RenameParamToMatchTypeRector.php
+++ b/src/SprykerSdk/Architector/Rename/RenameParamToMatchTypeRector.php
@@ -169,7 +169,7 @@ CODE_SAMPLE
             if ($expectedName === null) {
                 continue;
             }
-            
+
             $expectedName = $this->getExpectedName($expectedName);
 
             $paramRename = $this->paramRenameFactory->createFromResolvedExpectedName($param, $expectedName);

--- a/src/SprykerSdk/Architector/Rename/RenameParamToMatchTypeRector.php
+++ b/src/SprykerSdk/Architector/Rename/RenameParamToMatchTypeRector.php
@@ -53,6 +53,13 @@ class RenameParamToMatchTypeRector extends AbstractRector
      */
     private $paramRenamer;
 
+    /**
+     * @param \Rector\Naming\Guard\BreakingVariableRenameGuard $breakingVariableRenameGuard
+     * @param \Rector\Naming\Naming\ExpectedNameResolver $expectedNameResolver
+     * @param \Rector\Naming\ExpectedNameResolver\MatchParamTypeExpectedNameResolver $matchParamTypeExpectedNameResolver
+     * @param \Rector\Naming\ValueObjectFactory\ParamRenameFactory $paramRenameFactory
+     * @param \Rector\Naming\ParamRenamer\ParamRenamer $paramRenamer
+     */
     public function __construct(
         BreakingVariableRenameGuard $breakingVariableRenameGuard,
         ExpectedNameResolver $expectedNameResolver,
@@ -68,14 +75,15 @@ class RenameParamToMatchTypeRector extends AbstractRector
     }
 
     /**
-     * @return RuleDefinition
-     * @throws \Symplify\RuleDocGenerator\Exception\PoorDocumentationException
+     * @return \Symplify\RuleDocGenerator\ValueObject\RuleDefinition
      */
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Rename param to match ClassType',
+        return new RuleDefinition(
+            'Rename param to match ClassType',
             [
-                new CodeSample(<<<'CODE_SAMPLE'
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 class SomeClass
 {
     public function run(FooBarTransfer $fooBar)
@@ -83,8 +91,8 @@ class SomeClass
         $foo = $fooBar;
     }
 }
-CODE_SAMPLE
-                    , <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 class SomeClass
 {
     public function run(FooBarTransfer $fooBarTransfer)
@@ -92,9 +100,10 @@ class SomeClass
         $foo = $fooBarTransfer;
     }
 }
-CODE_SAMPLE
+CODE_SAMPLE,
                 ),
-                new CodeSample(<<<'CODE_SAMPLE'
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 class SomeClass
 {
     public function run(SpyFooBar $fooBar)
@@ -102,8 +111,8 @@ class SomeClass
         $foo = $fooBar;
     }
 }
-CODE_SAMPLE
-                    , <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 class SomeClass
 {
     public function run(SpyFooBar $fooBarEntity)
@@ -111,9 +120,10 @@ class SomeClass
         $foo = $fooBarEntity;
     }
 }
-CODE_SAMPLE
+CODE_SAMPLE,
                 ),
-                new CodeSample(<<<'CODE_SAMPLE'
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 class SomeClass
 {
     public function run(SpyFooBarQuery $fooBar)
@@ -121,8 +131,8 @@ class SomeClass
         $foo = $fooBar;
     }
 }
-CODE_SAMPLE
-                    , <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 class SomeClass
 {
     public function run(SpyFooBarQuery $fooBarQuery)
@@ -130,14 +140,14 @@ class SomeClass
         $foo = $fooBarQuery;
     }
 }
-CODE_SAMPLE
+CODE_SAMPLE,
                 ),
-            ]
+            ],
         );
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -146,6 +156,8 @@ CODE_SAMPLE
 
     /**
      * @param \PhpParser\Node\Stmt\ClassMethod $node
+     *
+     * @return \PhpParser\Node|null
      */
     public function refactor(Node $node): ?Node
     {
@@ -181,6 +193,7 @@ CODE_SAMPLE
             $this->paramRenamer->rename($paramRename);
             $this->hasChanged = \true;
         }
+
         if (!$this->hasChanged) {
             return null;
         }

--- a/src/SprykerSdk/Architector/TriggerError/TriggerErrorMessagesWithSprykerPrefixRector.php
+++ b/src/SprykerSdk/Architector/TriggerError/TriggerErrorMessagesWithSprykerPrefixRector.php
@@ -21,7 +21,7 @@ class TriggerErrorMessagesWithSprykerPrefixRector extends AbstractRector
     private string $sprykerPrefix = 'Spryker: ';
 
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -36,7 +36,9 @@ class TriggerErrorMessagesWithSprykerPrefixRector extends AbstractRector
     public function refactor(Node $node): ?Node
     {
         if ($this->getName($node) === 'trigger_error') {
-            $messageArgument = $node->args[0]->value;
+            /** @var \PhpParser\Node\Arg $firstArgument */
+            $firstArgument = $node->args[0];
+            $messageArgument = $firstArgument->value;
 
             if ($messageArgument instanceof Concat) {
                 return $this->refactorConcatinatedString($messageArgument, $node);
@@ -148,7 +150,9 @@ class TriggerErrorMessagesWithSprykerPrefixRector extends AbstractRector
             return null;
         }
 
-        $stringArgument = $messageArgument->args[0]->value;
+        /** @var \PhpParser\Node\Arg $firstArgument */
+        $firstArgument = $messageArgument->args[0];
+        $stringArgument = $firstArgument->value;
 
         if (!($stringArgument instanceof String_)) {
             return null;
@@ -190,45 +194,55 @@ class TriggerErrorMessagesWithSprykerPrefixRector extends AbstractRector
         return new RuleDefinition(
             'Refactors trigger_error calls to ensure the passed message contains "Spryker: " as prefix.',
             [
-                new CodeSample(<<<'CODE_SAMPLE'
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 trigger_error('My message', E_USER_DEPRECATED);
-CODE_SAMPLE, <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 trigger_error('Spryker: My message', E_USER_DEPRECATED);
-CODE_SAMPLE
+CODE_SAMPLE,
                 ),
-                new CodeSample(<<<'CODE_SAMPLE'
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 $message = 'Foo';
 trigger_error($message, E_USER_DEPRECATED);
-CODE_SAMPLE, <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 $message = 'Spryker: Foo';
 trigger_error($message, E_USER_DEPRECATED);
-CODE_SAMPLE
+CODE_SAMPLE,
                 ),
-                new CodeSample(<<<'CODE_SAMPLE'
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 $message = 'Foo' . 'Bar';
 trigger_error($message, E_USER_DEPRECATED);
-CODE_SAMPLE, <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 $message = 'Spryker: Foo' . 'Bar';
 trigger_error($message, E_USER_DEPRECATED);
-CODE_SAMPLE
+CODE_SAMPLE,
                 ),
-                new CodeSample(<<<'CODE_SAMPLE'
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 $message = 'Foo' . 'Bar' . 'Baz';
 trigger_error($message, E_USER_DEPRECATED);
-CODE_SAMPLE, <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 $message = 'Spryker: Foo' . 'Bar' . 'Baz';
 trigger_error($message, E_USER_DEPRECATED);
-CODE_SAMPLE
+CODE_SAMPLE,
                 ),
-                new CodeSample(<<<'CODE_SAMPLE'
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 $message = sprintf('Foo %s', $something);
 trigger_error($message, E_USER_DEPRECATED);
-CODE_SAMPLE, <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
 $message = sprintf('Spryker: Foo %s', $something);
 trigger_error($message, E_USER_DEPRECATED);
-CODE_SAMPLE
+CODE_SAMPLE,
                 ),
-            ]
+            ],
         );
     }
 }

--- a/tests/SprykerSdkTest/Architector/Codeception/PresentationToController/PresentationToControllerTest.php
+++ b/tests/SprykerSdkTest/Architector/Codeception/PresentationToController/PresentationToControllerTest.php
@@ -27,7 +27,7 @@ class PresentationToControllerTest extends AbstractRectorTestCase
     }
 
     /**
-     * @return Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
+     * @return \Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
      */
     public function provideData(): Iterator
     {

--- a/tests/SprykerSdkTest/Architector/Codeception/PresentationToControllerConfig/ConfigRector/PresentationToControllerConfigRectorTest.php
+++ b/tests/SprykerSdkTest/Architector/Codeception/PresentationToControllerConfig/ConfigRector/PresentationToControllerConfigRectorTest.php
@@ -26,7 +26,7 @@ class PresentationToControllerConfigRectorTest extends AbstractRectorTestCase
     }
 
     /**
-     * @return Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
+     * @return \Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
      */
     public function provideData(): Iterator
     {

--- a/tests/SprykerSdkTest/Architector/Codeception/PresentationToControllerTest/ClassConstFetchRector/ClassConstFetchRectorTest.php
+++ b/tests/SprykerSdkTest/Architector/Codeception/PresentationToControllerTest/ClassConstFetchRector/ClassConstFetchRectorTest.php
@@ -26,7 +26,7 @@ class ClassConstFetchRectorTest extends AbstractRectorTestCase
     }
 
     /**
-     * @return Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
+     * @return \Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
      */
     public function provideData(): Iterator
     {

--- a/tests/SprykerSdkTest/Architector/Codeception/PresentationToControllerTest/MethodParamRector/MethodParamRectorTest.php
+++ b/tests/SprykerSdkTest/Architector/Codeception/PresentationToControllerTest/MethodParamRector/MethodParamRectorTest.php
@@ -30,7 +30,7 @@ class MethodParamRectorTest extends AbstractRectorTestCase
     }
 
     /**
-     * @return Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
+     * @return \Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
      */
     public function provideData(): Iterator
     {

--- a/tests/SprykerSdkTest/Architector/Codeception/PresentationToControllerTest/NamespaceRector/NamespaceRectorTest.php
+++ b/tests/SprykerSdkTest/Architector/Codeception/PresentationToControllerTest/NamespaceRector/NamespaceRectorTest.php
@@ -26,7 +26,7 @@ class NamespaceRectorTest extends AbstractRectorTestCase
     }
 
     /**
-     * @return Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
+     * @return \Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
      */
     public function provideData(): Iterator
     {

--- a/tests/SprykerSdkTest/Architector/Codeception/PresentationToControllerTester/ClassNameRector/ClassNameRectorTest.php
+++ b/tests/SprykerSdkTest/Architector/Codeception/PresentationToControllerTester/ClassNameRector/ClassNameRectorTest.php
@@ -26,7 +26,7 @@ class ClassNameRectorTest extends AbstractRectorTestCase
     }
 
     /**
-     * @return Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
+     * @return \Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
      */
     public function provideData(): Iterator
     {

--- a/tests/SprykerSdkTest/Architector/Codeception/PresentationToControllerTester/TraitUseRector/TraitUseRectorTest.php
+++ b/tests/SprykerSdkTest/Architector/Codeception/PresentationToControllerTester/TraitUseRector/TraitUseRectorTest.php
@@ -26,7 +26,7 @@ class TraitUseRectorTest extends AbstractRectorTestCase
     }
 
     /**
-     * @return Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
+     * @return \Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
      */
     public function provideData(): Iterator
     {

--- a/tests/SprykerSdkTest/Architector/Codeception/RemoveInitialTesterComment/RemoveInitialTesterCommentRectorTest.php
+++ b/tests/SprykerSdkTest/Architector/Codeception/RemoveInitialTesterComment/RemoveInitialTesterCommentRectorTest.php
@@ -26,7 +26,7 @@ class RemoveInitialTesterCommentRectorTest extends AbstractRectorTestCase
     }
 
     /**
-     * @return Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
+     * @return \Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
      */
     public function provideData(): Iterator
     {

--- a/tests/SprykerSdkTest/Architector/Rename/RenameParamToMatchTypeRector/Fixture/rename-param-to-match-type-rector-propel-entity-test.php.inc
+++ b/tests/SprykerSdkTest/Architector/Rename/RenameParamToMatchTypeRector/Fixture/rename-param-to-match-type-rector-propel-entity-test.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Pyz\Zed\FooBar\Business\FooBar;
+
+use Orm\Zed\FooBar\Persistence\SpyFooBar;
+
+class FooBar
+{
+    /**
+     * @param \Orm\Zed\FooBar\Persistence\SpyFooBar $fooBar
+     *
+     * @return void
+     */
+    public function fooBarMethod(SpyFooBar $fooBar)
+    {
+        $foo = $fooBar;
+    }
+}
+-----
+<?php
+
+namespace Pyz\Zed\FooBar\Business\FooBar;
+
+use Orm\Zed\FooBar\Persistence\SpyFooBar;
+
+class FooBar
+{
+    /**
+     * @param \Orm\Zed\FooBar\Persistence\SpyFooBar $fooBarEntity
+     *
+     * @return void
+     */
+    public function fooBarMethod(SpyFooBar $fooBarEntity)
+    {
+        $foo = $fooBarEntity;
+    }
+}

--- a/tests/SprykerSdkTest/Architector/Rename/RenameParamToMatchTypeRector/Fixture/rename-param-to-match-type-rector-propel-query-test.php.inc
+++ b/tests/SprykerSdkTest/Architector/Rename/RenameParamToMatchTypeRector/Fixture/rename-param-to-match-type-rector-propel-query-test.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Pyz\Zed\FooBar\Business\FooBar;
+
+use Orm\Zed\FooBar\Persistence\SpyFooBarQuery;
+
+class FooBar
+{
+    /**
+     * @param \Orm\Zed\FooBar\Persistence\SpyFooBarQuery $fooBar
+     *
+     * @return void
+     */
+    public function fooBarMethod(SpyFooBarQuery $fooBar)
+    {
+        $foo = $fooBar;
+    }
+}
+-----
+<?php
+
+namespace Pyz\Zed\FooBar\Business\FooBar;
+
+use Orm\Zed\FooBar\Persistence\SpyFooBarQuery;
+
+class FooBar
+{
+    /**
+     * @param \Orm\Zed\FooBar\Persistence\SpyFooBarQuery $fooBarQuery
+     *
+     * @return void
+     */
+    public function fooBarMethod(SpyFooBarQuery $fooBarQuery)
+    {
+        $foo = $fooBarQuery;
+    }
+}

--- a/tests/SprykerSdkTest/Architector/Rename/RenameParamToMatchTypeRector/Fixture/rename-param-to-match-type-rector-test.php.inc
+++ b/tests/SprykerSdkTest/Architector/Rename/RenameParamToMatchTypeRector/Fixture/rename-param-to-match-type-rector-test.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Pyz\Zed\FooBar\Business\FooBar;
+
+use Generater\Shared\Transfer\FooBarTransfer;
+
+class FooBar
+{
+    /**
+     * @param \Generater\Shared\Transfer\FooBarTransfer $fooBar
+     *
+     * @return void
+     */
+    public function fooBarMethod(FooBarTransfer $fooBar)
+    {
+        $foo = $fooBar;
+    }
+}
+-----
+<?php
+
+namespace Pyz\Zed\FooBar\Business\FooBar;
+
+use Generater\Shared\Transfer\FooBarTransfer;
+
+class FooBar
+{
+    /**
+     * @param \Generater\Shared\Transfer\FooBarTransfer $fooBarTransfer
+     *
+     * @return void
+     */
+    public function fooBarMethod(FooBarTransfer $fooBarTransfer)
+    {
+        $foo = $fooBarTransfer;
+    }
+}

--- a/tests/SprykerSdkTest/Architector/Rename/RenameParamToMatchTypeRector/RenameParamToMatchTypeTest.php
+++ b/tests/SprykerSdkTest/Architector/Rename/RenameParamToMatchTypeRector/RenameParamToMatchTypeTest.php
@@ -33,7 +33,7 @@ class RenameParamToMatchTypeTest extends AbstractRectorTestCase
     }
 
     /**
-     * @return Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
+     * @return \Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
      */
     public function provideData(): Iterator
     {

--- a/tests/SprykerSdkTest/Architector/Rename/RenameParamToMatchTypeRector/RenameParamToMatchTypeTest.php
+++ b/tests/SprykerSdkTest/Architector/Rename/RenameParamToMatchTypeRector/RenameParamToMatchTypeTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdkTest\Architector\Rename\RenameParamToMatchType;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @group SprykerSdkTest
+ * @group Architector
+ * @group SprykerSdkTest
+ * @group RenameParamToMatchType
+ * @group RenameParamToMatchTypeTest
+ */
+class RenameParamToMatchTypeTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     *
+     * @param \Symplify\SmartFileSystem\SmartFileInfo $fileInfo
+     *
+     * @return void
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @return string
+     */
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/tests/SprykerSdkTest/Architector/Rename/RenameParamToMatchTypeRector/config/config.php
+++ b/tests/SprykerSdkTest/Architector/Rename/RenameParamToMatchTypeRector/config/config.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types = 1);
 
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use SprykerSdk\Architector\Rename\RenameParamToMatchTypeRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (
     ContainerConfigurator $containerConfigurator

--- a/tests/SprykerSdkTest/Architector/Rename/RenameParamToMatchTypeRector/config/config.php
+++ b/tests/SprykerSdkTest/Architector/Rename/RenameParamToMatchTypeRector/config/config.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use SprykerSdk\Architector\Rename\RenameParamToMatchTypeRector;
+
+return static function (
+    ContainerConfigurator $containerConfigurator
+): void {
+    $services = $containerConfigurator->services();
+    $services->set(RenameParamToMatchTypeRector::class);
+};

--- a/tests/SprykerSdkTest/Architector/TriggerError/RemoveInitialTesterCommentRectorTest.php
+++ b/tests/SprykerSdkTest/Architector/TriggerError/RemoveInitialTesterCommentRectorTest.php
@@ -26,7 +26,7 @@ class RemoveInitialTesterCommentRectorTest extends AbstractRectorTestCase
     }
 
     /**
-     * @return Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
+     * @return \Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
      */
     public function provideData(): Iterator
     {


### PR DESCRIPTION
Added RenameParamToMatchTypeRector that is capable of creating names for Propel and Transfer classes that follow the Spryker convention.