### PR TITLE
Use AllowEmptyConfigurableRectorInterface

### DIFF
--- a/src/SprykerSdk/Architector/Rename/RenameParamToMatchTypeRector.php
+++ b/src/SprykerSdk/Architector/Rename/RenameParamToMatchTypeRector.php
@@ -14,7 +14,7 @@ use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use Propel\Runtime\Collection\ObjectCollection;
-use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Contract\Rector\AllowEmptyConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
 use Rector\Naming\ExpectedNameResolver\MatchParamTypeExpectedNameResolver;
@@ -30,7 +30,7 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Throwable;
 
-class RenameParamToMatchTypeRector extends AbstractRector implements ConfigurableRectorInterface
+class RenameParamToMatchTypeRector extends AbstractRector implements AllowEmptyConfigurableRectorInterface
 {
     /**
      * @var string


### PR DESCRIPTION
Used AllowEmptyConfigurableRectorInterface to be able to run rector without configuring it and to use the default configuration.